### PR TITLE
Refine localization prompts

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,8 @@ import type React from "react"
 import type { Metadata } from "next"
 import "./globals.css"
 
+import { LanguageProvider } from "@/components/language-provider"
+
 export const metadata: Metadata = {
   title: "Primer - Your Magical Learning Companion",
   description:
@@ -17,7 +19,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className="font-sans antialiased">
-        {children}
+        <LanguageProvider>{children}</LanguageProvider>
       </body>
     </html>
   )

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,16 +1,24 @@
 "use client"
 
 import { useCallback, useEffect, useState } from "react"
+import { useTranslations } from "next-intl"
+import { KeyRound, Rocket, Settings, ShieldCheck, Sparkles } from "lucide-react"
+
 import { PrimerOrb } from "@/components/primer-orb"
 import { SettingsPanel } from "@/components/settings-panel"
 import { Button } from "@/components/ui/button"
-import { KeyRound, Rocket, Settings, ShieldCheck, Sparkles } from "lucide-react"
 
 interface LandingContentProps {
   onGetStarted: () => void
 }
 
 function LandingContent({ onGetStarted }: LandingContentProps) {
+  const howItems = [
+    "Create nightly storytime adventures personalized to your child's interests.",
+    "Review homework concepts in plain language and encourage curiosity with follow-up questions.",
+    "Spark deeper conversations about science, art, and big feelings in a calm, supportive tone.",
+  ]
+
   return (
     <div className="relative z-10 flex min-h-screen w-full flex-col justify-center px-6 py-16">
       <div className="mx-auto max-w-6xl space-y-16">
@@ -20,18 +28,23 @@ function LandingContent({ onGetStarted }: LandingContentProps) {
               Open source · Realtime AI · Built for families
             </span>
             <h1 className="text-4xl font-semibold leading-tight text-foreground md:text-5xl">
-              Open Primer and <span className="bg-gradient-to-r from-primary via-secondary to-accent bg-clip-text text-transparent">Learn</span>
+              Open Primer and
+              <span className="bg-gradient-to-r from-primary via-secondary to-accent bg-clip-text text-transparent">
+                {" "}
+                Learn
+              </span>
             </h1>
             <p className="text-lg text-muted-foreground md:text-xl">
-              Primer is an open-source companion that uses OpenAI&apos;s Realtime API to help your child explore ideas through warm,
-              conversational guidance—while you stay in complete control of the experience. Give your child their own personalized learning experience without sharing your OpenAI account.
+              Primer is an open-source companion that uses OpenAI's Realtime API to help your child explore ideas through warm,
+              conversational guidance—while you stay in complete control of the experience. Give your child their own
+              personalized learning experience without sharing your OpenAI account.
             </p>
             <div className="flex flex-col items-center gap-4 md:flex-row md:items-center">
               <Button size="lg" className="h-12 rounded-full px-8 text-base shadow-lg" onClick={onGetStarted}>
                 Begin setup
               </Button>
               <p className="text-sm text-muted-foreground md:text-left">
-                Set your family&apos;s OpenAI key to unlock the orb experience and personalize Primer&apos;s voice and tone.
+                Set your family's OpenAI key to unlock the orb experience and personalize Primer's voice and tone.
               </p>
             </div>
           </div>
@@ -45,7 +58,8 @@ function LandingContent({ onGetStarted }: LandingContentProps) {
                 <div>
                   <h3 className="text-xl font-semibold">Why Primer?</h3>
                   <p className="text-sm text-muted-foreground">
-                    We believe AI should feel like a thoughtful mentor—not a toy. Primer focuses on curiosity, safety, and deep learning moments. Built by a team that includes parents and trained developmental psychology specialists.
+                    We believe AI should feel like a thoughtful mentor—not a toy. Primer focuses on curiosity, safety, and deep
+                    learning moments. Built by a team that includes parents and trained developmental psychology specialists.
                   </p>
                 </div>
               </div>
@@ -56,7 +70,8 @@ function LandingContent({ onGetStarted }: LandingContentProps) {
                 <div>
                   <h3 className="text-xl font-semibold">Private by design</h3>
                   <p className="text-sm text-muted-foreground">
-                    Nobody will read your child&apos;s data. Keys stay in your browser, and conversations remain entirely yours. We don&apos;t have servers to store your data—we literally can&apos;t access it even if we wanted to.
+                    Nobody will read your child's data. Keys stay in your browser, and conversations remain entirely yours. We
+                    don't have servers to store your data—we literally can't access it even if we wanted to.
                   </p>
                 </div>
               </div>
@@ -67,7 +82,8 @@ function LandingContent({ onGetStarted }: LandingContentProps) {
                 <div>
                   <h3 className="text-xl font-semibold">Made to iterate</h3>
                   <p className="text-sm text-muted-foreground">
-                    No VC funding. No salaries. Just full transparency through open source. You can audit every line, customize the prompt, and trust that we cannot leak your data even if we wanted to—there&apos;s nothing to leak.
+                    No VC funding. No salaries. Just full transparency through open source. You can audit every line, customize
+                    the prompt, and trust that we cannot leak your data even if we wanted to—there's nothing to leak.
                   </p>
                 </div>
               </div>
@@ -79,9 +95,11 @@ function LandingContent({ onGetStarted }: LandingContentProps) {
           <div className="space-y-4">
             <h2 className="text-2xl font-semibold">How families use Primer</h2>
             <ul className="space-y-3 text-sm text-muted-foreground">
-              <li className="rounded-2xl border border-border/60 bg-background/60 p-4">Create nightly storytime adventures personalized to your child&apos;s interests.</li>
-              <li className="rounded-2xl border border-border/60 bg-background/60 p-4">Review homework concepts in plain language and encourage curiosity with follow-up questions.</li>
-              <li className="rounded-2xl border border-border/60 bg-background/60 p-4">Spark deeper conversations about science, art, and big feelings in a calm, supportive tone.</li>
+              {howItems.map((item) => (
+                <li key={item} className="rounded-2xl border border-border/60 bg-background/60 p-4">
+                  {item}
+                </li>
+              ))}
             </ul>
           </div>
           <div className="space-y-5">
@@ -98,7 +116,7 @@ function LandingContent({ onGetStarted }: LandingContentProps) {
                     rel="noopener noreferrer"
                     className="font-medium text-foreground underline decoration-primary/60 decoration-2 underline-offset-4"
                   >
-                    OpenAI&apos;s dashboard
+                    OpenAI's dashboard
                   </a>{" "}
                   and create a dedicated project for Primer.
                 </div>
@@ -109,7 +127,7 @@ function LandingContent({ onGetStarted }: LandingContentProps) {
               </li>
               <li className="flex gap-5">
                 <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-accent/10 text-sm font-semibold text-accent">3</span>
-                <div className="pt-1">Store the key in Primer&apos;s settings and keep a secure copy in your password manager for safe keeping.</div>
+                <div className="pt-1">Store the key in Primer's settings and keep a secure copy in your password manager for safe keeping.</div>
               </li>
             </ol>
             <div className="flex items-center gap-3 rounded-2xl border border-border/60 bg-background/60 p-4 text-sm text-muted-foreground">
@@ -124,6 +142,8 @@ function LandingContent({ onGetStarted }: LandingContentProps) {
 }
 
 export default function PrimerPage() {
+  const orb = useTranslations("orb")
+  const settings = useTranslations("settings")
   const [showSettings, setShowSettings] = useState(false)
   const [hasApiKey, setHasApiKey] = useState<boolean | null>(null)
 
@@ -190,7 +210,7 @@ export default function PrimerPage() {
           className="rounded-full shadow-lg bg-card/80 backdrop-blur-sm hover:bg-card"
         >
           <Settings className="h-5 w-5" />
-          <span className="sr-only">Settings</span>
+          <span className="sr-only">{settings("openButton")}</span>
         </Button>
       </div>
 
@@ -203,19 +223,19 @@ export default function PrimerPage() {
                 Primer
               </h1>
               <p className="mx-auto max-w-md text-balance text-lg md:text-xl text-muted-foreground">
-                Your magical learning companion
+                {orb("tagline")}
               </p>
             </div>
 
             <PrimerOrb />
 
             <div className="mt-12 max-w-sm text-center text-sm text-muted-foreground">
-              <p className="text-balance">Tap the orb to start a conversation with Primer</p>
+              <p className="text-balance">{orb("hint")}</p>
             </div>
           </div>
         ) : hasApiKey === null ? (
           <div className="flex flex-1 items-center justify-center">
-            <p className="text-sm text-muted-foreground">Loading your settings…</p>
+            <p className="text-sm text-muted-foreground">{orb("loading")}</p>
           </div>
         ) : (
           <LandingContent onGetStarted={handleGetStarted} />

--- a/components/language-provider.tsx
+++ b/components/language-provider.tsx
@@ -1,0 +1,67 @@
+"use client"
+
+import { NextIntlClientProvider } from "next-intl"
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react"
+
+import { defaultLocale, type Locale, isLocale } from "@/lib/i18n/config"
+import { localeMessages } from "@/lib/i18n/messages"
+
+interface LanguageContextValue {
+  locale: Locale
+  setLocale: (locale: Locale) => void
+}
+
+const LanguageContext = createContext<LanguageContextValue | undefined>(undefined)
+
+export function LanguageProvider({ children }: { children: ReactNode }) {
+  const [locale, setLocaleState] = useState<Locale>(defaultLocale)
+
+  useEffect(() => {
+    const storedLocale = localStorage.getItem("primer_language")
+    if (isLocale(storedLocale)) {
+      setLocaleState(storedLocale)
+    }
+  }, [])
+
+  useEffect(() => {
+    document.documentElement.lang = locale
+  }, [locale])
+
+  const handleSetLocale = useCallback((nextLocale: Locale) => {
+    setLocaleState(nextLocale)
+    localStorage.setItem("primer_language", nextLocale)
+  }, [])
+
+  const contextValue = useMemo(
+    () => ({
+      locale,
+      setLocale: handleSetLocale,
+    }),
+    [handleSetLocale, locale],
+  )
+
+  return (
+    <LanguageContext.Provider value={contextValue}>
+      <NextIntlClientProvider locale={locale} messages={localeMessages[locale]}>
+        {children}
+      </NextIntlClientProvider>
+    </LanguageContext.Provider>
+  )
+}
+
+export function useLanguage() {
+  const context = useContext(LanguageContext)
+  if (!context) {
+    throw new Error("useLanguage must be used within a LanguageProvider")
+  }
+
+  return context
+}

--- a/components/language-provider.tsx
+++ b/components/language-provider.tsx
@@ -23,11 +23,23 @@ const LanguageContext = createContext<LanguageContextValue | undefined>(undefine
 
 export function LanguageProvider({ children }: { children: ReactNode }) {
   const [locale, setLocaleState] = useState<Locale>(defaultLocale)
+  const [timeZone, setTimeZone] = useState<string>("UTC")
 
   useEffect(() => {
     const storedLocale = localStorage.getItem("primer_language")
     if (isLocale(storedLocale)) {
       setLocaleState(storedLocale)
+    }
+  }, [])
+
+  useEffect(() => {
+    try {
+      const resolved = Intl.DateTimeFormat().resolvedOptions().timeZone
+      if (resolved) {
+        setTimeZone(resolved)
+      }
+    } catch {
+      // ignore - keep default UTC fallback
     }
   }, [])
 
@@ -50,7 +62,7 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
 
   return (
     <LanguageContext.Provider value={contextValue}>
-      <NextIntlClientProvider locale={locale} messages={localeMessages[locale]}>
+      <NextIntlClientProvider locale={locale} messages={localeMessages[locale]} timeZone={timeZone}>
         {children}
       </NextIntlClientProvider>
     </LanguageContext.Provider>

--- a/components/primer-orb.tsx
+++ b/components/primer-orb.tsx
@@ -1,12 +1,15 @@
 "use client"
 
 import { useState, useEffect, useRef } from "react"
+import { useTranslations } from "next-intl"
+
 import { Button } from "@/components/ui/button"
 import { useRealtimeAgent } from "@/hooks/use-realtime-agent"
 
 type OrbState = "idle" | "muted" | "listening" | "thinking" | "speaking"
 
 export function PrimerOrb() {
+  const t = useTranslations("orb")
   const [orbState, setOrbState] = useState<OrbState>("idle")
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const animationRef = useRef<number | undefined>(undefined)
@@ -148,7 +151,7 @@ export function PrimerOrb() {
           onClick={handleOrbClick}
           disabled={isConnected}
           className="relative block rounded-full overflow-hidden shadow-2xl transition-transform hover:scale-105 active:scale-95 focus:outline-none focus:ring-4 focus:ring-primary/50 disabled:cursor-default disabled:hover:scale-100"
-          aria-label={isConnected ? "Connected - speak to Primer" : "Connect to Primer"}
+          aria-label={isConnected ? t("aria.connected") : t("aria.connect")}
         >
           <canvas ref={canvasRef} width={300} height={300} className="w-[300px] h-[300px]" />
         </button>
@@ -156,12 +159,12 @@ export function PrimerOrb() {
         {/* State indicator */}
         <div className="absolute -bottom-2 left-1/2 -translate-x-1/2 px-4 py-1.5 rounded-full bg-card/90 backdrop-blur-sm shadow-lg border">
           <p className="text-sm font-medium">
-            {!isConnected && "Click to start"}
-            {isConnected && orbState === "idle" && "Ready to chat"}
-            {isConnected && orbState === "muted" && "Getting ready..."}
-            {orbState === "listening" && "Listening..."}
-            {orbState === "thinking" && "Thinking..."}
-            {orbState === "speaking" && "Speaking..."}
+            {!isConnected && t("cta.start")}
+            {isConnected && orbState === "idle" && t("state.idle")}
+            {isConnected && orbState === "muted" && t("state.muted")}
+            {orbState === "listening" && t("state.listening")}
+            {orbState === "thinking" && t("state.thinking")}
+            {orbState === "speaking" && t("state.speaking")}
           </p>
         </div>
       </div>
@@ -174,19 +177,19 @@ export function PrimerOrb() {
             onClick={handleDisconnect}
             className="rounded-full shadow-lg bg-transparent"
           >
-            End Chat
+            {t("cta.endChat")}
           </Button>
         </div>
       )}
 
       {isConnected && orbState !== "muted" && (
         <p className="text-sm text-muted-foreground text-center max-w-md">
-          Just start speaking! Primer is listening and will respond automatically.
+          {t("cta.listeningHint")}
         </p>
       )}
       {isConnected && orbState === "muted" && (
         <p className="text-sm text-muted-foreground text-center max-w-md">
-          Primer is saying hello—your microphone will open in just a moment.
+          {t("cta.mutedHint")}
         </p>
       )}
     </div>

--- a/components/settings-panel.tsx
+++ b/components/settings-panel.tsx
@@ -13,6 +13,11 @@ import { Textarea } from "@/components/ui/textarea"
 import { useLanguage } from "@/components/language-provider"
 import { locales, type Locale, isLocale } from "@/lib/i18n/config"
 
+const LANGUAGE_DISPLAY_NAMES: Record<Locale, string> = {
+  en: "🇬🇧 English",
+  pl: "🇵🇱 Polski",
+}
+
 interface SettingsPanelProps {
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -109,7 +114,7 @@ export function SettingsPanel({ open, onOpenChange, onApiKeyChange }: SettingsPa
             >
               {locales.map((code) => (
                 <option key={code} value={code}>
-                  {t(`language.options.${code}` as const)}
+                  {LANGUAGE_DISPLAY_NAMES[code]}
                 </option>
               ))}
             </select>

--- a/components/settings-panel.tsx
+++ b/components/settings-panel.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useEffect, useState, type ReactNode } from "react"
 import { useTranslations } from "next-intl"
 import { Info, Save } from "lucide-react"
 
@@ -133,7 +133,7 @@ export function SettingsPanel({ open, onOpenChange, onApiKeyChange }: SettingsPa
               <Info className="h-4 w-4" />
               <AlertDescription className="text-sm">
                 {t.rich("apiKey.hint", {
-                  link: (chunks) => (
+                  link: (chunks: ReactNode) => (
                     <a
                       href="https://platform.openai.com/api-keys"
                       target="_blank"
@@ -187,7 +187,7 @@ export function SettingsPanel({ open, onOpenChange, onApiKeyChange }: SettingsPa
             <Info className="h-4 w-4" />
             <AlertDescription className="text-sm">
               {t.rich("notes.content", {
-                strong: (chunks) => <strong>{chunks}</strong>,
+                strong: (chunks: ReactNode) => <strong>{chunks}</strong>,
               })}
             </AlertDescription>
           </Alert>

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -101,6 +101,7 @@ Since Primer is a privacy-focused, standalone application, success cannot be mea
 ### 9.1. Phases
    - **Phase 1 (MVP)**:
      - Key deliverables: A simple UI with a button to trigger voice chat, integration with OpenAI's APIs, and a settings panel to store the API key and a custom system prompt in `localStorage`.
+     - Localization note: Only the orb experience and settings panel are translated; the public landing page remains English-only for the initial release.
    - **Future Phases (Community Driven)**:
      - Key deliverables: Image generation features, development of guided "curriculums," and integrations with other external data sources. The settings could be enhanced to be stored and managed via import/export or linked to a user's OpenAI account resources (e.g., Assistants).
 

--- a/hooks/use-realtime-agent.ts
+++ b/hooks/use-realtime-agent.ts
@@ -233,8 +233,12 @@ export function useRealtimeAgent(options: UseRealtimeAgentOptions = {}): UseReal
                         handleStateChange("muted")
                         console.log("[Primer] Ready to chat!")
 
-			const welcomeInstructions =
-				"Speak a short, encouraging welcome so the child knows you are ready to chat. Say something like: \"Hi there! I'm Primer, your learning buddy. What would you like to explore today?\""
+                        const welcomeInstructions = [
+                                orbT("prompt.welcome"),
+                                languageInstruction,
+                        ]
+                                .filter(Boolean)
+                                .join("\n\n")
 
                         session.mute(true)
                         console.log("[Primer] Muted microphone for welcome message")

--- a/lib/i18n/config.ts
+++ b/lib/i18n/config.ts
@@ -1,0 +1,16 @@
+export const locales = ["en", "pl"] as const
+
+export type Locale = (typeof locales)[number]
+
+export const defaultLocale: Locale = "en"
+
+const localeSet = new Set<Locale>(locales)
+
+export function isLocale(value: string | null | undefined): value is Locale {
+  if (!value) {
+    return false
+  }
+
+  return localeSet.has(value as Locale)
+}
+

--- a/lib/i18n/messages.ts
+++ b/lib/i18n/messages.ts
@@ -1,31 +1,23 @@
-import { isLocale, locales, type Locale } from "./config"
+import { type Locale } from "./config"
 
-type MessagesByNamespace = Record<string, unknown>
+import orbEn from "@/messages/orb/en.json"
+import orbPl from "@/messages/orb/pl.json"
+import settingsEn from "@/messages/settings/en.json"
+import settingsPl from "@/messages/settings/pl.json"
 
-const modules = import.meta.glob("../../messages/**/*.json", { eager: true }) as Record<
-  string,
-  { default: MessagesByNamespace }
->
+type NamespaceMessages = Record<string, unknown>
 
-const localeMessages = Object.fromEntries(locales.map((locale) => [locale, {}])) as Record<
-  Locale,
-  MessagesByNamespace
->
+type LocaleMessages = Record<Locale, Record<string, NamespaceMessages>>
 
-for (const [path, module] of Object.entries(modules)) {
-  const match = path.match(/\.\.\/\.\.\/messages\/([^/]+)\/([a-z-]+)\.json$/i)
-
-  if (!match) {
-    continue
-  }
-
-  const [, namespace, locale] = match
-
-  if (!isLocale(locale)) {
-    continue
-  }
-
-  localeMessages[locale][namespace] = module.default
+const localeMessages: LocaleMessages = {
+  en: {
+    orb: orbEn,
+    settings: settingsEn,
+  },
+  pl: {
+    orb: orbPl,
+    settings: settingsPl,
+  },
 }
 
 export { localeMessages }

--- a/lib/i18n/messages.ts
+++ b/lib/i18n/messages.ts
@@ -1,0 +1,31 @@
+import { isLocale, locales, type Locale } from "./config"
+
+type MessagesByNamespace = Record<string, unknown>
+
+const modules = import.meta.glob("../../messages/**/*.json", { eager: true }) as Record<
+  string,
+  { default: MessagesByNamespace }
+>
+
+const localeMessages = Object.fromEntries(locales.map((locale) => [locale, {}])) as Record<
+  Locale,
+  MessagesByNamespace
+>
+
+for (const [path, module] of Object.entries(modules)) {
+  const match = path.match(/\.\.\/\.\.\/messages\/([^/]+)\/([a-z-]+)\.json$/i)
+
+  if (!match) {
+    continue
+  }
+
+  const [, namespace, locale] = match
+
+  if (!isLocale(locale)) {
+    continue
+  }
+
+  localeMessages[locale][namespace] = module.default
+}
+
+export { localeMessages }

--- a/messages/orb/en.json
+++ b/messages/orb/en.json
@@ -1,0 +1,29 @@
+{
+  "tagline": "Your magical learning companion",
+  "hint": "Tap the orb to start a conversation with Primer",
+  "loading": "Loading your settings…",
+  "cta": {
+    "start": "Click to start",
+    "endChat": "End Chat",
+    "listeningHint": "Just start speaking! Primer is listening and will respond automatically.",
+    "mutedHint": "Primer is saying hello—your microphone will open in just a moment."
+  },
+  "state": {
+    "idle": "Ready to chat",
+    "muted": "Getting ready...",
+    "listening": "Listening...",
+    "thinking": "Thinking...",
+    "speaking": "Speaking..."
+  },
+  "aria": {
+    "connect": "Connect to Primer",
+    "connected": "Connected - speak to Primer"
+  },
+  "errors": {
+    "apiKeyMissing": "Please set your OpenAI API key in settings first!",
+    "session": "Realtime session error. Please check the console for details."
+  },
+  "prompt": {
+    "languageInstruction": "Please respond in English."
+  }
+}

--- a/messages/orb/en.json
+++ b/messages/orb/en.json
@@ -24,6 +24,7 @@
     "session": "Realtime session error. Please check the console for details."
   },
   "prompt": {
-    "languageInstruction": "Please respond in English."
+    "languageInstruction": "Please respond in English.",
+    "welcome": "Speak a short, encouraging welcome so the child knows you are ready to chat. Say something like: \"Hi there! I'm Primer, your learning buddy. What would you like to explore today?\""
   }
 }

--- a/messages/orb/pl.json
+++ b/messages/orb/pl.json
@@ -24,6 +24,7 @@
     "session": "Błąd sesji Realtime. Sprawdź konsolę, aby poznać szczegóły."
   },
   "prompt": {
-    "languageInstruction": "Proszę odpowiadać po polsku."
+    "languageInstruction": "Proszę odpowiadać po polsku.",
+    "welcome": "Przywitaj się krótko i serdecznie, aby dziecko wiedziało, że jesteś gotowa do rozmowy. Powiedz coś w stylu: \"Cześć! Jestem Primer, Twoja towarzyszka nauki. O czym chcesz dziś porozmawiać?\""
   }
 }

--- a/messages/orb/pl.json
+++ b/messages/orb/pl.json
@@ -1,0 +1,29 @@
+{
+  "tagline": "Twoja magiczna towarzyszka nauki",
+  "hint": "Dotknij kuli, aby rozpocząć rozmowę z Primer",
+  "loading": "Wczytywanie ustawień…",
+  "cta": {
+    "start": "Kliknij, aby rozpocząć",
+    "endChat": "Zakończ rozmowę",
+    "listeningHint": "Po prostu zacznij mówić! Primer słucha i odpowie automatycznie.",
+    "mutedHint": "Primer wita się — mikrofon włączy się za chwilę."
+  },
+  "state": {
+    "idle": "Gotowa do rozmowy",
+    "muted": "Przygotowuję się...",
+    "listening": "Słucham...",
+    "thinking": "Myślę...",
+    "speaking": "Mówię..."
+  },
+  "aria": {
+    "connect": "Połącz z Primer",
+    "connected": "Połączono — mów do Primer"
+  },
+  "errors": {
+    "apiKeyMissing": "Najpierw ustaw swój klucz API OpenAI w ustawieniach!",
+    "session": "Błąd sesji Realtime. Sprawdź konsolę, aby poznać szczegóły."
+  },
+  "prompt": {
+    "languageInstruction": "Proszę odpowiadać po polsku."
+  }
+}

--- a/messages/settings/en.json
+++ b/messages/settings/en.json
@@ -1,0 +1,30 @@
+{
+  "openButton": "Settings",
+  "title": "Parent Settings",
+  "description": "Configure Primer's behavior and connection settings",
+  "language": {
+    "label": "Language",
+    "description": "Choose how Primer and the interface speak. This also updates the system prompt automatically.",
+    "options": {
+      "en": "English",
+      "pl": "Polski"
+    }
+  },
+  "apiKey": {
+    "label": "OpenAI API Key",
+    "hint": "Your API key is stored locally in your browser and never sent to our servers. When you connect, it's exchanged for a short-lived ephemeral key for secure WebRTC communication. Get your key from <link>OpenAI's platform</link>."
+  },
+  "prompt": {
+    "label": "System Prompt",
+    "reset": "Reset to Default",
+    "description": "Customize how Primer interacts with your child. This prompt guides the AI's personality and behavior.",
+    "default": "You are Primer, a magical learning companion for children inspired by \"The Young Lady's Illustrated Primer\" from Neal Stephenson's Diamond Age.\n\nYour role is to:\n- Be warm, encouraging, and patient\n- Explain concepts in age-appropriate ways\n- Ask thoughtful questions to encourage curiosity\n- Celebrate learning and discovery\n- Keep conversations safe and educational\n- Use storytelling to make learning engaging\n\nAlways maintain a friendly, supportive tone and adapt your explanations to the child's level of understanding."
+  },
+  "actions": {
+    "save": "Save Settings",
+    "saved": "\u2713 Settings saved successfully!"
+  },
+  "notes": {
+    "content": "<strong>Note:</strong> Changes take effect the next time you start a conversation with Primer."
+  }
+}

--- a/messages/settings/en.json
+++ b/messages/settings/en.json
@@ -4,11 +4,7 @@
   "description": "Configure Primer's behavior and connection settings",
   "language": {
     "label": "Language",
-    "description": "Choose how Primer and the interface speak. This also updates the system prompt automatically.",
-    "options": {
-      "en": "English",
-      "pl": "Polski"
-    }
+    "description": "Choose how Primer and the interface speak. This also updates the system prompt automatically."
   },
   "apiKey": {
     "label": "OpenAI API Key",

--- a/messages/settings/pl.json
+++ b/messages/settings/pl.json
@@ -4,11 +4,7 @@
   "description": "Skonfiguruj zachowanie i ustawienia połączenia Primer",
   "language": {
     "label": "Język",
-    "description": "Wybierz, w jakim języku mówi Primer i interfejs. To ustawienie automatycznie aktualizuje prompt systemowy.",
-    "options": {
-      "en": "Angielski",
-      "pl": "Polski"
-    }
+    "description": "Wybierz, w jakim języku mówi Primer i interfejs. To ustawienie automatycznie aktualizuje prompt systemowy."
   },
   "apiKey": {
     "label": "Klucz API OpenAI",

--- a/messages/settings/pl.json
+++ b/messages/settings/pl.json
@@ -1,0 +1,30 @@
+{
+  "openButton": "Ustawienia",
+  "title": "Ustawienia rodzica",
+  "description": "Skonfiguruj zachowanie i ustawienia połączenia Primer",
+  "language": {
+    "label": "Język",
+    "description": "Wybierz, w jakim języku mówi Primer i interfejs. To ustawienie automatycznie aktualizuje prompt systemowy.",
+    "options": {
+      "en": "Angielski",
+      "pl": "Polski"
+    }
+  },
+  "apiKey": {
+    "label": "Klucz API OpenAI",
+    "hint": "Twój klucz API jest przechowywany lokalnie w przeglądarce i nigdy nie trafia na nasze serwery. Podczas łączenia jest wymieniany na krótkotrwały klucz efemeryczny dla bezpiecznej komunikacji WebRTC. Pobierz klucz z <link>platformy OpenAI</link>."
+  },
+  "prompt": {
+    "label": "Prompt systemowy",
+    "reset": "Przywróć domyślny",
+    "description": "Dostosuj sposób, w jaki Primer rozmawia z Twoim dzieckiem. Ten prompt określa osobowość i zachowanie AI.",
+    "default": "Jesteś Primer, magiczną towarzyszką nauki dla dzieci inspirowaną \"Ilustrowanym elementarzem dla dziewczynek\" Neala Stephensona z powieści \"Diamentowy wiek\".\n\nTwoja rola to:\n- Być ciepłą, wspierającą i cierpliwą\n- Wyjaśniać zagadnienia w sposób dostosowany do wieku\n- Zadawać przemyślane pytania, by pobudzać ciekawość\n- Świętować naukę i odkrycia\n- Dbać, by rozmowy były bezpieczne i edukacyjne\n- Wykorzystywać opowieści, by nauka była angażująca\n\nZawsze zachowuj przyjazny, wspierający ton i dostosowuj wyjaśnienia do poziomu zrozumienia dziecka."
+  },
+  "actions": {
+    "save": "Zapisz ustawienia",
+    "saved": "\u2713 Pomyślnie zapisano ustawienia!"
+  },
+  "notes": {
+    "content": "<strong>Uwaga:</strong> Zmiany zaczną obowiązywać przy następnym rozpoczęciu rozmowy z Primer."
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "clsx": "^2.1.1",
         "lucide-react": "^0.454.0",
         "next": "^15.5.6",
+        "next-intl": "^4.3.12",
         "react": "^19",
         "react-dom": "^19",
         "tailwind-merge": "^2.5.5",
@@ -209,6 +210,66 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
+      "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/intl-localematcher": "0.6.2",
+        "decimal.js": "^10.4.3",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/ecma402-abstract/node_modules/@formatjs/intl-localematcher": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
+      "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
+      "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/icu-skeleton-parser": "1.8.16",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.16",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
+      "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.10.tgz",
+      "integrity": "sha512-af3qATX+m4Rnd9+wHcjJ4w2ijq+rAVP3CCinJQvFv1kgSu1W6jypUmvleJxcewdxmutM8dmIRZFxO/IQBZmP2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1385,6 +1446,12 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.14.0.tgz",
       "integrity": "sha512-WJFej426qe4RWOm9MMtP4V3CV4AucXolQty+GRgAWLgQXmpCuwzs7hEpxxhSc/znXUSxum9d/P/32MW0FlAAlA==",
       "dev": true
+    },
+    "node_modules/@schummar/icu-type-parser": {
+      "version": "1.21.5",
+      "resolved": "https://registry.npmjs.org/@schummar/icu-type-parser/-/icu-type-parser-1.21.5.tgz",
+      "integrity": "sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==",
+      "license": "MIT"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -2918,6 +2985,12 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -4245,6 +4318,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/intl-messageformat": {
+      "version": "10.7.18",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
+      "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.4",
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -5217,7 +5302,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
-      "optional": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -5269,6 +5353,33 @@
           "optional": true
         },
         "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-intl": {
+      "version": "4.3.12",
+      "resolved": "https://registry.npmjs.org/next-intl/-/next-intl-4.3.12.tgz",
+      "integrity": "sha512-yAmrQ3yx0zpNva/knniDvam3jT2d01Lv2aRgRxUIDL9zm9O4AsDjWbDIxX13t5RNf0KVnKkxH+iRcqEAmWecPg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/intl-localematcher": "^0.5.4",
+        "negotiator": "^1.0.0",
+        "use-intl": "^4.3.12"
+      },
+      "peerDependencies": {
+        "next": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0",
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
           "optional": true
         }
       }
@@ -6763,7 +6874,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6865,6 +6976,20 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-intl": {
+      "version": "4.3.12",
+      "resolved": "https://registry.npmjs.org/use-intl/-/use-intl-4.3.12.tgz",
+      "integrity": "sha512-RxW2/D17irlDOJOzClKl+kWA7ReGLpo/A8f/LF7w1kIxO6mPKVh422JJ/pDCcvtYFCI4aPtn1AXUfELKbM+7tg==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "^2.2.0",
+        "@schummar/icu-type-parser": "1.21.5",
+        "intl-messageformat": "^10.5.14"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
       }
     },
     "node_modules/use-sidecar": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.454.0",
     "next": "^15.5.6",
+    "next-intl": "^4.3.12",
     "react": "^19",
     "react-dom": "^19",
     "tailwind-merge": "^2.5.5",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,6 @@
       "@/*": ["./*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.d.ts", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
 }

--- a/types/import-meta.d.ts
+++ b/types/import-meta.d.ts
@@ -1,7 +1,0 @@
-export {}
-
-declare global {
-  interface ImportMeta {
-    glob(pattern: string, options: { eager: true }): Record<string, unknown>
-  }
-}

--- a/types/import-meta.d.ts
+++ b/types/import-meta.d.ts
@@ -1,0 +1,7 @@
+export {}
+
+declare global {
+  interface ImportMeta {
+    glob(pattern: string, options: { eager: true }): Record<string, unknown>
+  }
+}


### PR DESCRIPTION
## Summary
- source the settings panel prompt defaults from translations while keeping the API key placeholder static
- build realtime agent instructions from the saved prompt plus the locale-specific language directive provided by the orb messages
- load locale bundles automatically via import.meta.glob with supporting type declarations and the new language-instruction strings

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68f61d3202008323bc906f6bc78ca7f3